### PR TITLE
Adjust the order of events and record elapsed time when async invoke.

### DIFF
--- a/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AbstractCluster.java
+++ b/core-impl/client/src/main/java/com/alipay/sofa/rpc/client/AbstractCluster.java
@@ -542,11 +542,16 @@ public abstract class AbstractCluster extends Cluster {
                         request.setSofaResponseCallback(methodResponseCallback);
                     }
                 }
+                // 记录发送开始时间
+                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.now());
+                // 开始调用
                 transport.asyncSend(request, timeout);
                 response = buildEmptyResponse(request);
             }
             // Future调用
             else if (RpcConstants.INVOKER_TYPE_FUTURE.equals(invokeType)) {
+                // 记录发送开始时间
+                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.now());
                 // 开始调用
                 ResponseFuture future = transport.asyncSend(request, timeout);
                 // 放入线程上下文

--- a/core/api/src/main/java/com/alipay/sofa/rpc/client/ClientProxyInvoker.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/client/ClientProxyInvoker.java
@@ -86,8 +86,10 @@ public class ClientProxyInvoker implements Invoker {
                 throw e;
             } finally {
                 // 产生调用结束事件
-                if (EventBus.isEnable(ClientEndInvokeEvent.class)) {
-                    EventBus.post(new ClientEndInvokeEvent(request, response, throwable));
+                if (!request.isAsync()) {
+                    if (EventBus.isEnable(ClientEndInvokeEvent.class)) {
+                        EventBus.post(new ClientEndInvokeEvent(request, response, throwable));
+                    }
                 }
             }
             // 包装响应

--- a/core/api/src/main/java/com/alipay/sofa/rpc/common/RpcConstants.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/common/RpcConstants.java
@@ -198,11 +198,11 @@ public class RpcConstants {
     public static final String  HIDDEN_KEY_DESTROY                 = HIDE_KEY_PREFIX + "destroy";
 
     /**
-     * 内部使用的key：_app_name
+     * 内部使用的key：_app_name，string
      */
     public static final String  INTERNAL_KEY_APP_NAME              = INTERNAL_KEY_PREFIX + "app_name";
     /**
-     * 内部使用的key：_protocol_name
+     * 内部使用的key：_protocol_name，string
      */
     public static final String  INTERNAL_KEY_PROTOCOL_NAME         = INTERNAL_KEY_PREFIX + "protocol_name";
     /**
@@ -230,27 +230,33 @@ public class RpcConstants {
      */
     public static final String  INTERNAL_KEY_RESP_DESERIALIZE_TIME = INTERNAL_KEY_PREFIX + "resp_des_time";
     /**
-     * 内部使用的key：_process_wait_time 在业务线程池里等待时间
+     * 内部使用的key：_process_wait_time 在业务线程池里等待时间，long
      */
     public static final String  INTERNAL_KEY_PROCESS_WAIT_TIME     = INTERNAL_KEY_PREFIX + "process_wait_time";
     /**
-     * 内部使用的key：_conn_create_time 长连接建立时间 需要一个 (long) 类型数据
+     * 内部使用的key：_conn_create_time 长连接建立时间，long
      */
     public static final String  INTERNAL_KEY_CONN_CREATE_TIME      = INTERNAL_KEY_PREFIX + "conn_create_time";
     /**
-     * 内部使用的key：_impl_elapse 业务代码执行耗时
+     * 内部使用的key：_impl_elapse 业务代码执行耗时，long
      */
     public static final String  INTERNAL_KEY_IMPL_ELAPSE           = INTERNAL_KEY_PREFIX + "impl_elapse";
     /**
-     * 内部使用的key：_client_elapse 客户端总耗时
+     * 内部使用的key：_client_elapse 客户端总耗时，long
      */
     public static final String  INTERNAL_KEY_CLIENT_ELAPSE         = INTERNAL_KEY_PREFIX + "client_elapse";
     /**
-     * 内部使用的key：_router_record 路由记录
+     * 内部使用的key：_client_send_time 客户端发送时间戳，long
+     * 
+     * @since 5.4.0
+     */
+    public static final String  INTERNAL_KEY_CLIENT_SEND_TIME      = INTERNAL_KEY_PREFIX + "client_send_time";
+    /**
+     * 内部使用的key：_router_record 路由记录，string
      */
     public static final String  INTERNAL_KEY_ROUTER_RECORD         = INTERNAL_KEY_PREFIX + "router_record";
     /**
-     * 内部使用的key：_invoke_times 调用次数
+     * 内部使用的key：_invoke_times 调用次数，int
      */
     public static final String  INTERNAL_KEY_INVOKE_TIMES          = INTERNAL_KEY_PREFIX + "invoke_times";
     /**
@@ -285,7 +291,7 @@ public class RpcConstants {
      */
     public static final String  CONFIG_KEY_GENERIC                 = "generic";
     /**
-     * 配置key:async
+     * 配置key:invokeType
      */
     public static final String  CONFIG_KEY_INVOKE_TYPE             = "invokeType";
     /**
@@ -304,7 +310,7 @@ public class RpcConstants {
     public static final String  CONFIG_KEY_CONCURRENTS             = "concurrents";
 
     /**
-     * 配置key:params
+     * 配置key:parameters
      */
     public static final String  CONFIG_KEY_PARAMS                  = "parameters";
 

--- a/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInternalContext.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/context/RpcInternalContext.java
@@ -29,8 +29,8 @@ import com.alipay.sofa.rpc.message.ResponseFuture;
 import java.net.InetSocketAddress;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 基于ThreadLocal的内部使用的上下文传递。一般存在于：客户端请求线程、服务端业务线程池、客户端异步线程<br>
@@ -168,7 +168,7 @@ public class RpcInternalContext implements Cloneable {
      *
      * @see #ATTACHMENT_ENABLE
      */
-    private Map<String, Object>     attachments = new HashMap<String, Object>();
+    private Map<String, Object>     attachments = new ConcurrentHashMap<String, Object>();
 
     /**
      * The Stopwatch
@@ -339,7 +339,7 @@ public class RpcInternalContext implements Cloneable {
      * @return attachment attachment
      */
     public Object getAttachment(String key) {
-        return attachments.get(key);
+        return key == null ? null : attachments.get(key);
     }
 
     /**
@@ -376,11 +376,10 @@ public class RpcInternalContext implements Cloneable {
      * remove attachment.
      *
      * @param key the key
-     * @return context rpc context
+     * @return Old value
      */
-    public RpcInternalContext removeAttachment(String key) {
-        attachments.remove(key);
-        return this;
+    public Object removeAttachment(String key) {
+        return attachments.remove(key);
     }
 
     /**
@@ -434,7 +433,7 @@ public class RpcInternalContext implements Cloneable {
     public void clear() {
         this.setRemoteAddress(null).setLocalAddress(null).setFuture(null).setProviderSide(null)
             .setProviderInfo(null).setInterfaceConfig(null);
-        this.attachments = new HashMap<String, Object>();
+        this.attachments = new ConcurrentHashMap<String, Object>();
         this.stopWatch.reset();
     }
 
@@ -484,7 +483,7 @@ public class RpcInternalContext implements Cloneable {
 
     @Override
     public String toString() {
-        return "RpcInternalContext{" +
+        return super.toString() + "{" +
             "future=" + future +
             ", localAddress=" + localAddress +
             ", remoteAddress=" + remoteAddress +

--- a/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallback.java
+++ b/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallback.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.message.bolt;
+
+import com.alipay.remoting.InvokeCallback;
+import com.alipay.sofa.rpc.client.ProviderInfo;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.context.BaggageResolver;
+import com.alipay.sofa.rpc.context.RpcInternalContext;
+import com.alipay.sofa.rpc.context.RpcInvokeContext;
+import com.alipay.sofa.rpc.context.RpcRuntimeContext;
+import com.alipay.sofa.rpc.core.request.SofaRequest;
+import com.alipay.sofa.rpc.core.response.SofaResponse;
+
+/**
+ * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
+ * @since 5.4.0
+ */
+public abstract class AbstractInvokeCallback implements InvokeCallback {
+    /**
+     * 服务消费者配置
+     */
+    protected final ConsumerConfig consumerConfig;
+    /**
+     * 服务提供者信息
+     */
+    protected final ProviderInfo   providerInfo;
+    /**
+     * 请求
+     */
+    protected final SofaRequest    request;
+    /**
+     * 请求运行时的ClassLoader
+     */
+    protected ClassLoader          classLoader;
+    /**
+     * 线程上下文
+     */
+    protected RpcInternalContext   context;
+
+    protected AbstractInvokeCallback(ConsumerConfig consumerConfig, ProviderInfo providerInfo, SofaRequest request,
+                                     RpcInternalContext context, ClassLoader classLoader) {
+        this.consumerConfig = consumerConfig;
+        this.providerInfo = providerInfo;
+        this.request = request;
+        this.context = context;
+        this.classLoader = classLoader;
+    }
+
+    protected void recordClientElapseTime() {
+        if (context != null) {
+            Long startTime = (Long) context.removeAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME);
+            if (startTime != null) {
+                context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE, RpcRuntimeContext.now() - startTime);
+            }
+        }
+    }
+
+    protected void pickupBaggage(SofaResponse response) {
+        if (RpcInvokeContext.isBaggageEnable()) {
+            RpcInvokeContext invokeCtx = null;
+            if (context != null) {
+                invokeCtx = (RpcInvokeContext) context.getAttachment(RpcConstants.HIDDEN_KEY_INVOKE_CONTEXT);
+            }
+            if (invokeCtx == null) {
+                invokeCtx = RpcInvokeContext.getContext();
+            } else {
+                RpcInvokeContext.setContext(invokeCtx);
+            }
+            BaggageResolver.pickupFromResponse(invokeCtx, response);
+        }
+    }
+}

--- a/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/transport/bolt/BoltClientTransport.java
+++ b/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/transport/bolt/BoltClientTransport.java
@@ -204,8 +204,6 @@ public class BoltClientTransport extends ClientTransport {
         InvokeContext boltInvokeContext = createInvokeContext(request);
         try {
             beforeSend(context, request);
-            // 复制一份上下文
-            context = context.clone();
             boltInvokeContext.put(RemotingConstants.INVOKE_CTX_RPC_CTX, context);
             return doInvokeAsync(request, context, boltInvokeContext, timeout);
         } catch (Exception e) {

--- a/extension-impl/remoting-bolt/src/test/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallbackTest.java
+++ b/extension-impl/remoting-bolt/src/test/java/com/alipay/sofa/rpc/message/bolt/AbstractInvokeCallbackTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.message.bolt;
+
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.context.RpcInternalContext;
+import com.alipay.sofa.rpc.context.RpcRuntimeContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
+ */
+public class AbstractInvokeCallbackTest {
+
+    @Test
+    public void testRecordClientElapseTime() {
+        BoltInvokerCallback invokerCallback = new BoltInvokerCallback(null, null,
+            null, null, null, null);
+        invokerCallback.recordClientElapseTime();
+        Long elapse = (Long) RpcInternalContext.getContext().getAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE);
+        Assert.assertNull(elapse);
+
+        RpcInternalContext context = RpcInternalContext.getContext();
+        invokerCallback = new BoltInvokerCallback(null, null,
+            null, null, context, null);
+        invokerCallback.recordClientElapseTime();
+        elapse = (Long) context.getAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE);
+        Assert.assertNull(elapse);
+
+        context.setAttachment(RpcConstants.INTERNAL_KEY_CLIENT_SEND_TIME, RpcRuntimeContext.now() - 1000);
+        invokerCallback.recordClientElapseTime();
+        elapse = (Long) context.getAttachment(RpcConstants.INTERNAL_KEY_CLIENT_ELAPSE);
+        Assert.assertNotNull(elapse);
+    }
+}


### PR DESCRIPTION
### Motivation:

Adjust the order of events and record elapsed time when async invoke.

### Modification:

- `ClientEndInvokeEvent` will not post before async invoke return real response.
- Adjust the order of events when async invoke.
- Record elapsed time when async invoke.

### Result:

Fixes #125 
