### PR TITLE
Remove return type of Serializer#decode.

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/codec/Serializer.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/codec/Serializer.java
@@ -59,8 +59,7 @@ public interface Serializer {
      * @param data     原始字节数组
      * @param template 模板对象
      * @param context  上下文
-     * @return 反序列化后的对象
      * @throws SofaRpcException 序列化异常
      */
-    public Object decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException;
+    public void decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException;
 }

--- a/core/api/src/test/java/com/alipay/sofa/rpc/codec/AbstractSerializerTest.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/codec/AbstractSerializerTest.java
@@ -43,8 +43,7 @@ public class AbstractSerializerTest extends AbstractSerializer {
     }
 
     @Override
-    public Object decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException {
-        return null;
+    public void decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException {
     }
 
     @Test

--- a/core/api/src/test/java/com/alipay/sofa/rpc/codec/TestSerializer.java
+++ b/core/api/src/test/java/com/alipay/sofa/rpc/codec/TestSerializer.java
@@ -41,7 +41,7 @@ public class TestSerializer extends AbstractSerializer {
     }
 
     @Override
-    public Object decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException {
-        return null;
+    public void decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException {
+
     }
 }

--- a/extension-impl/codec-protobuf/src/main/java/com/alipay/sofa/rpc/codec/protobuf/ProtobufSerializer.java
+++ b/extension-impl/codec-protobuf/src/main/java/com/alipay/sofa/rpc/codec/protobuf/ProtobufSerializer.java
@@ -174,19 +174,19 @@ public class ProtobufSerializer extends AbstractSerializer {
     }
 
     @Override
-    public Object decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException {
+    public void decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException {
         if (template == null) {
             throw buildDeserializeError("template is null!");
         } else if (template instanceof SofaRequest) {
-            return decodeSofaRequest(data, (SofaRequest) template, context);
+            decodeSofaRequest(data, (SofaRequest) template, context);
         } else if (template instanceof SofaResponse) {
-            return decodeSofaResponse(data, (SofaResponse) template, context);
+            decodeSofaResponse(data, (SofaResponse) template, context);
         } else {
-            return decode(data, template.getClass(), context);
+            throw buildDeserializeError("Only support decode from SofaRequest and SofaResponse template");
         }
     }
 
-    private SofaRequest decodeSofaRequest(AbstractByteBuf data, SofaRequest sofaRequest, Map<String, String> head) {
+    private void decodeSofaRequest(AbstractByteBuf data, SofaRequest sofaRequest, Map<String, String> head) {
         if (head == null) {
             throw buildDeserializeError("head is null!");
         }
@@ -225,7 +225,6 @@ public class ProtobufSerializer extends AbstractSerializer {
         Object pbReq = decode(data, requestClass, head);
         sofaRequest.setMethodArgs(new Object[] { pbReq });
         sofaRequest.setMethodArgSigs(new String[] { requestClass.getName() });
-        return sofaRequest;
     }
 
     private void parseRequestHeader(String key, Map<String, String> headerMap,
@@ -237,7 +236,7 @@ public class ProtobufSerializer extends AbstractSerializer {
         }
     }
 
-    private SofaResponse decodeSofaResponse(AbstractByteBuf data, SofaResponse sofaResponse, Map<String, String> head) {
+    private void decodeSofaResponse(AbstractByteBuf data, SofaResponse sofaResponse, Map<String, String> head) {
         if (head == null) {
             throw buildDeserializeError("head is null!");
         }
@@ -266,6 +265,5 @@ public class ProtobufSerializer extends AbstractSerializer {
             Object pbRes = decode(data, responseClass, head);
             sofaResponse.setAppResponse(pbRes);
         }
-        return sofaResponse;
     }
 }

--- a/extension-impl/codec-protobuf/src/test/java/com/alipay/sofa/rpc/codec/protobuf/ProtobufSerializerTest.java
+++ b/extension-impl/codec-protobuf/src/test/java/com/alipay/sofa/rpc/codec/protobuf/ProtobufSerializerTest.java
@@ -74,8 +74,13 @@ public class ProtobufSerializerTest {
         }
         Assert.assertTrue(error);
 
-        dst = (String) serializer.decode(data, "", null);
-        Assert.assertEquals("xxx", dst);
+        error = false;
+        try {
+            serializer.decode(data, "", null);
+        } catch (Exception e) {
+            error = true;
+        }
+        Assert.assertTrue(error);
     }
 
     @Test
@@ -106,7 +111,8 @@ public class ProtobufSerializerTest {
         head.put(RemotingConstants.RPC_TRACE_NAME + ".b", "yyy");
         head.put("unkown", "yes");
 
-        SofaRequest newRequest = (SofaRequest) serializer.decode(data, new SofaRequest(), head);
+        SofaRequest newRequest = new SofaRequest();
+        serializer.decode(data, newRequest, head);
 
         Assert.assertEquals(newRequest.getInterfaceName(), request.getInterfaceName());
         Assert.assertEquals(newRequest.getMethodName(), request.getMethodName());
@@ -125,7 +131,8 @@ public class ProtobufSerializerTest {
         head.put(RemotingConstants.HEAD_TARGET_APP, "targetApp");
         head.put(RemotingConstants.RPC_TRACE_NAME + ".a", "xxx");
         head.put(RemotingConstants.RPC_TRACE_NAME + ".b", "yyy");
-        newRequest = (SofaRequest) serializer.decode(new ByteArrayWrapperByteBuf(new byte[0]), new SofaRequest(), head);
+        newRequest = new SofaRequest();
+        serializer.decode(new ByteArrayWrapperByteBuf(new byte[0]), newRequest, head);
         Assert.assertEquals("", ((EchoStrReq) newRequest.getMethodArgs()[0]).getS());
     }
 
@@ -168,7 +175,8 @@ public class ProtobufSerializerTest {
         response = new SofaResponse();
         response.setAppResponse(EchoStrRes.newBuilder().setS("result").build());
         data = serializer.encode(response, null);
-        SofaResponse newResponse = (SofaResponse) serializer.decode(data, new SofaResponse(), head);
+        SofaResponse newResponse = new SofaResponse();
+        serializer.decode(data, newResponse, head);
         Assert.assertFalse(newResponse.isError());
         Assert.assertEquals(response.getAppResponse(), newResponse.getAppResponse());
         Assert.assertEquals("result", ((EchoStrRes) newResponse.getAppResponse()).getS());
@@ -179,8 +187,8 @@ public class ProtobufSerializerTest {
         head.put(RemotingConstants.HEAD_METHOD_NAME, "echoStr");
         head.put(RemotingConstants.RPC_TRACE_NAME + ".a", "xxx");
         head.put(RemotingConstants.RPC_TRACE_NAME + ".b", "yyy");
-        newResponse = (SofaResponse) serializer.decode(new ByteArrayWrapperByteBuf(new byte[0]),
-            new SofaResponse(), head);
+        newResponse = new SofaResponse();
+        serializer.decode(new ByteArrayWrapperByteBuf(new byte[0]), newResponse, head);
         Assert.assertFalse(newResponse.isError());
         Assert.assertNotNull(newResponse.getAppResponse());
         Assert.assertEquals("", ((EchoStrRes) newResponse.getAppResponse()).getS());
@@ -195,7 +203,8 @@ public class ProtobufSerializerTest {
         response = new SofaResponse();
         response.setErrorMsg("1233");
         data = serializer.encode(response, null);
-        newResponse = (SofaResponse) serializer.decode(data, new SofaResponse(), head);
+        newResponse = new SofaResponse();
+        serializer.decode(data, newResponse, head);
         Assert.assertTrue(newResponse.isError());
         Assert.assertEquals(response.getErrorMsg(), newResponse.getErrorMsg());
     }

--- a/extension-impl/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/SofaHessianSerializer.java
+++ b/extension-impl/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/SofaHessianSerializer.java
@@ -59,7 +59,7 @@ import java.util.Map;
  *
  * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
  */
-@Extension(value = "sofahessian", code = 1)
+@Extension(value = "hessian2", code = 1)
 public class SofaHessianSerializer extends AbstractSerializer {
 
     /**

--- a/extension-impl/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/SofaHessianSerializer.java
+++ b/extension-impl/codec-sofa-hessian/src/main/java/com/alipay/sofa/rpc/codec/sofahessian/SofaHessianSerializer.java
@@ -204,11 +204,16 @@ public class SofaHessianSerializer extends AbstractSerializer {
     }
 
     @Override
-    public Object decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException {
+    public void decode(AbstractByteBuf data, Object template, Map<String, String> context) throws SofaRpcException {
         if (template == null) {
             throw buildDeserializeError("template is null!");
+        } else if (template instanceof SofaRequest) {
+            decodeSofaRequestByTemplate(data, context, (SofaRequest) template);
+        } else if (template instanceof SofaResponse) {
+            decodeSofaResponseByTemplate(data, context, (SofaResponse) template);
+        } else {
+            throw buildDeserializeError("Only support decode from SofaRequest and SofaResponse template");
         }
-        return decode(data, template.getClass(), context);
     }
 
     /**
@@ -249,6 +254,50 @@ public class SofaHessianSerializer extends AbstractSerializer {
     }
 
     /**
+     * Do decode  SofaRequest
+     *
+     * @param data     AbstractByteBuf
+     * @param context  上下文
+     * @param template SofaRequest template
+     * @throws SofaRpcException 序列化出现异常
+     */
+    protected void decodeSofaRequestByTemplate(AbstractByteBuf data, Map<String, String> context,
+                                               SofaRequest template) throws SofaRpcException {
+        try {
+            UnsafeByteArrayInputStream inputStream = new UnsafeByteArrayInputStream(data.array());
+            Hessian2Input input = new Hessian2Input(inputStream);
+            input.setSerializerFactory(serializerFactory);
+            Object object = input.readObject();
+            SofaRequest tmp = (SofaRequest) object;
+            String targetServiceName = tmp.getTargetServiceUniqueName();
+            if (targetServiceName == null) {
+                throw buildDeserializeError("Target service name of request is null!");
+            }
+            // copy values to template
+            template.setMethodName(tmp.getMethodName());
+            template.setMethodArgSigs(tmp.getMethodArgSigs());
+            template.setTargetServiceUniqueName(tmp.getTargetServiceUniqueName());
+            template.setTargetAppName(tmp.getTargetAppName());
+            template.addRequestProps(tmp.getRequestProps());
+
+            String interfaceName = ConfigUniqueNameGenerator.getInterfaceName(targetServiceName);
+            template.setInterfaceName(interfaceName);
+
+            // decode args
+            String[] sig = template.getMethodArgSigs();
+            Class<?>[] classSig = ClassTypeUtils.getClasses(sig);
+            final Object[] args = new Object[sig.length];
+            for (int i = 0; i < template.getMethodArgSigs().length; ++i) {
+                args[i] = input.readObject(classSig[i]);
+            }
+            template.setMethodArgs(args);
+            input.close();
+        } catch (IOException e) {
+            throw buildDeserializeError(e.getMessage(), e);
+        }
+    }
+
+    /**
      * Do decode SofaResponse
      *
      * @param data    AbstractByteBuf
@@ -271,6 +320,7 @@ public class SofaHessianSerializer extends AbstractSerializer {
                 SofaResponse sofaResponse = new SofaResponse();
                 sofaResponse.setErrorMsg((String) genericObject.getField("errorMsg"));
                 sofaResponse.setAppResponse(genericObject.getField("appResponse"));
+                sofaResponse.setResponseProps((Map<String, String>) genericObject.getField("responseProps"));
                 object = sofaResponse;
             } else {
                 input.setSerializerFactory(serializerFactory);
@@ -278,6 +328,42 @@ public class SofaHessianSerializer extends AbstractSerializer {
             }
             input.close();
             return (SofaResponse) object;
+        } catch (IOException e) {
+            throw buildDeserializeError(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Do decode SofaResponse
+     *
+     * @param data     AbstractByteBuf
+     * @param context  上下文
+     * @param template SofaResponse template
+     * @throws SofaRpcException 序列化出现异常
+     */
+    protected void decodeSofaResponseByTemplate(AbstractByteBuf data, Map<String, String> context,
+                                                SofaResponse template) throws SofaRpcException {
+        try {
+            UnsafeByteArrayInputStream inputStream = new UnsafeByteArrayInputStream(data.array());
+            Hessian2Input input = new Hessian2Input(inputStream);
+            // 根据SerializeType信息决定序列化器
+            boolean genericSerialize = context != null && isGenericResponse(
+                context.get(RemotingConstants.HEAD_GENERIC_TYPE));
+            if (genericSerialize) {
+                input.setSerializerFactory(genericSerializerFactory);
+                GenericObject genericObject = (GenericObject) input.readObject();
+                template.setErrorMsg((String) genericObject.getField("errorMsg"));
+                template.setAppResponse(genericObject.getField("appResponse"));
+                template.setResponseProps((Map<String, String>) genericObject.getField("responseProps"));
+            } else {
+                input.setSerializerFactory(serializerFactory);
+                SofaResponse tmp = (SofaResponse) input.readObject();
+                // copy values to template
+                template.setErrorMsg(tmp.getErrorMsg());
+                template.setAppResponse(tmp.getAppResponse());
+                template.setResponseProps(tmp.getResponseProps());
+            }
+            input.close();
         } catch (IOException e) {
             throw buildDeserializeError(e.getMessage(), e);
         }

--- a/extension-impl/codec-sofa-hessian/src/main/resources/META-INF/services/sofa-rpc/com.alipay.sofa.rpc.codec.Serializer
+++ b/extension-impl/codec-sofa-hessian/src/main/resources/META-INF/services/sofa-rpc/com.alipay.sofa.rpc.codec.Serializer
@@ -1,1 +1,1 @@
-sofahessian=com.alipay.sofa.rpc.codec.sofahessian.SofaHessianSerializer
+hessian2=com.alipay.sofa.rpc.codec.sofahessian.SofaHessianSerializer

--- a/extension-impl/codec-sofa-hessian/src/test/java/com/alipay/sofa/rpc/codec/sofahessian/SofaHessianSerializerTest.java
+++ b/extension-impl/codec-sofa-hessian/src/test/java/com/alipay/sofa/rpc/codec/sofahessian/SofaHessianSerializerTest.java
@@ -56,10 +56,15 @@ public class SofaHessianSerializerTest {
         String dst = (String) serializer.decode(data, String.class, null);
         Assert.assertEquals("xxx", dst);
 
-        dst = (String) serializer.decode(data, "", null);
-        Assert.assertEquals("xxx", dst);
-
         boolean error = false;
+        try {
+            serializer.decode(data, "", null);
+        } catch (Exception e) {
+            error = true;
+        }
+        Assert.assertTrue(error);
+
+        error = false;
         try {
             serializer.decode(data, null, null);
         } catch (Exception e) {

--- a/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java
+++ b/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java
@@ -258,19 +258,14 @@ public class SofaRpcSerialization extends DefaultCustomSerializer {
                     Serializer rpcSerializer = com.alipay.sofa.rpc.codec.SerializerFactory
                         .getSerializer(requestCommand.getSerializer());
                     SofaRequest sofaRequest = new SofaRequest();
-                    sofaRequest = (SofaRequest) rpcSerializer.decode(
-                        new ByteArrayWrapperByteBuf(requestCommand.getContent()), sofaRequest, headerMap);
-                    if (sofaRequest == null) {
-                        throw new DeserializationException("Decode request return null!");
-                    }
+                    rpcSerializer.decode(new ByteArrayWrapperByteBuf(requestCommand.getContent()),
+                        sofaRequest, headerMap);
                     requestCommand.setRequestObject(sofaRequest);
                 } finally {
                     Thread.currentThread().setContextClassLoader(oldClassLoader);
                 }
 
                 return true;
-            } catch (DeserializationException ex) {
-                throw ex;
             } catch (Exception ex) {
                 throw new DeserializationException(ex.getMessage(), ex);
             } finally {
@@ -364,8 +359,7 @@ public class SofaRpcSerialization extends DefaultCustomSerializer {
                     (String) invokeContext.get(RemotingConstants.HEAD_GENERIC_TYPE));
 
                 Serializer rpcSerializer = com.alipay.sofa.rpc.codec.SerializerFactory.getSerializer(serializer);
-                sofaResponse = (SofaResponse) rpcSerializer.decode(
-                    new ByteArrayWrapperByteBuf(responseCommand.getContent()), sofaResponse, header);
+                rpcSerializer.decode(new ByteArrayWrapperByteBuf(responseCommand.getContent()), sofaResponse, header);
 
                 responseCommand.setResponseObject(sofaResponse);
                 return true;


### PR DESCRIPTION
### Motivation:

- Remove return type of `Serializer#decode`
- Change extension alias of `SofaHessianSerializer` to `hessian2`

#116 