### PR TITLE
Full epoll support on linux.

### DIFF
--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/ServerConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/ServerConfig.java
@@ -217,7 +217,8 @@ public class ServerConfig extends AbstractIdConfig implements Serializable {
     /**
      * 是否长连接
      */
-    protected boolean  keepAlive = true;
+    protected boolean                         keepAlive        = true;
+
     /**
      * 启动服务
      *

--- a/core/api/src/main/java/com/alipay/sofa/rpc/config/ServerConfig.java
+++ b/core/api/src/main/java/com/alipay/sofa/rpc/config/ServerConfig.java
@@ -215,6 +215,10 @@ public class ServerConfig extends AbstractIdConfig implements Serializable {
     private transient String                  boundHost;
 
     /**
+     * 是否长连接
+     */
+    protected boolean  keepAlive = true;
+    /**
      * 启动服务
      *
      * @return the server
@@ -815,6 +819,22 @@ public class ServerConfig extends AbstractIdConfig implements Serializable {
      */
     public String getBoundHost() {
         return boundHost;
+    }
+
+    /**
+     * Get KeepAlive
+     * @return 是否长连接
+     */
+    public boolean isKeepAlive() {
+        return keepAlive;
+    }
+
+    /**
+     * set KeepAlive
+     * @param keepAlive 是否长连接
+     */
+    public void setKeepAlive(boolean keepAlive) {
+        this.keepAlive = keepAlive;
     }
 
     /**

--- a/extension-impl/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/AbstractHttp2ClientTransport.java
+++ b/extension-impl/remoting-http/src/main/java/com/alipay/sofa/rpc/transport/http/AbstractHttp2ClientTransport.java
@@ -51,6 +51,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -137,7 +138,7 @@ public abstract class AbstractHttp2ClientTransport extends ClientTransport {
             int port = providerInfo.getPort();
             Bootstrap b = new Bootstrap();
             b.group(workerGroup);
-            b.channel(NioSocketChannel.class);
+            b.channel(transportConfig.isUseEpoll() ? EpollSocketChannel.class : NioSocketChannel.class);
             b.option(ChannelOption.SO_KEEPALIVE, true);
             b.remoteAddress(host, port);
             b.handler(initializer);

--- a/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/RestServer.java
+++ b/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/RestServer.java
@@ -73,7 +73,7 @@ public class RestServer implements Server {
 
     private SofaNettyJaxrsServer buildServer() {
         // 生成Server对象
-        SofaNettyJaxrsServer httpServer = new SofaNettyJaxrsServer();
+        SofaNettyJaxrsServer httpServer = new SofaNettyJaxrsServer(serverConfig);
 
         int bossThreads = serverConfig.getIoThreads();
         if (bossThreads > 0) {

--- a/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/RestServer.java
+++ b/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/RestServer.java
@@ -83,9 +83,6 @@ public class RestServer implements Server {
         httpServer.setMaxRequestSize(serverConfig.getPayload());
         httpServer.setHostname(serverConfig.getBoundHost());
         httpServer.setPort(serverConfig.getPort());
-        httpServer.setTelnet(serverConfig.isTelnet());
-        httpServer.setKeepAlive(true); // keepAlive TODO 可配置
-        httpServer.setDaemon(serverConfig.isDaemon());
 
         ResteasyDeployment resteasyDeployment = httpServer.getDeployment();
         resteasyDeployment.start();

--- a/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/SofaNettyJaxrsServer.java
+++ b/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/SofaNettyJaxrsServer.java
@@ -19,12 +19,16 @@ package com.alipay.sofa.rpc.server.rest;
 import com.alipay.sofa.rpc.common.SystemInfo;
 import com.alipay.sofa.rpc.common.struct.NamedThreadFactory;
 import com.alipay.sofa.rpc.common.utils.StringUtils;
+import com.alipay.sofa.rpc.config.ServerConfig;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -59,6 +63,7 @@ import static org.jboss.resteasy.plugins.server.netty.RestEasyHttpRequestDecoder
  */
 public class SofaNettyJaxrsServer implements EmbeddedJaxrsServer {
 
+    private ServerConfig               serverConfig;
     protected ServerBootstrap          bootstrap           = new ServerBootstrap();
     protected String                   hostname            = null;
     protected int                      port                = 8080;
@@ -79,6 +84,13 @@ public class SofaNettyJaxrsServer implements EmbeddedJaxrsServer {
     protected boolean                  keepAlive           = false;                       // CHANGE:是否长连接
     protected boolean                  telnet              = true;                        // CHANGE:是否允许telnet
     protected boolean                  daemon              = true;                        // CHANGE:是否守护线程
+
+    public SofaNettyJaxrsServer() {
+    }
+
+    public SofaNettyJaxrsServer(ServerConfig serverConfig) {
+        this.serverConfig = serverConfig;
+    }
 
     public void setSSLContext(SSLContext sslContext) {
         this.sslContext = sslContext;
@@ -206,12 +218,22 @@ public class SofaNettyJaxrsServer implements EmbeddedJaxrsServer {
     @Override
     public void start() {
         // CHANGE: 增加线程名字
-        eventLoopGroup = new NioEventLoopGroup(ioWorkerCount, new NamedThreadFactory("SEV-REST-IO-" + port, daemon));
-        eventExecutor = new NioEventLoopGroup(executorThreadCount, new NamedThreadFactory("SEV-REST-BIZ-" + port,
-            daemon));
+        if (serverConfig != null && serverConfig.isEpoll()) {
+            eventLoopGroup = new EpollEventLoopGroup(ioWorkerCount, new NamedThreadFactory("SEV-REST-IO-" + port,
+                daemon));
+            eventExecutor = new EpollEventLoopGroup(executorThreadCount, new NamedThreadFactory("SEV-REST-BIZ-" + port,
+                daemon));
+        } else {
+            eventLoopGroup = new NioEventLoopGroup(ioWorkerCount, new NamedThreadFactory("SEV-REST-IO-" + port, daemon));
+            eventExecutor = new NioEventLoopGroup(executorThreadCount, new NamedThreadFactory("SEV-REST-BIZ-" + port,
+                daemon));
+        }
         // Configure the server.
-        bootstrap.group(eventLoopGroup)
-            .channel(NioServerSocketChannel.class)
+        bootstrap
+            .group(eventLoopGroup)
+            .channel(
+                (serverConfig != null && serverConfig.isEpoll()) ? EpollServerSocketChannel.class
+                    : NioServerSocketChannel.class)
             .childHandler(createChannelInitializer())
             .option(ChannelOption.SO_BACKLOG, backlog)
             .childOption(ChannelOption.SO_KEEPALIVE, keepAlive); // CHANGE:

--- a/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/SofaNettyJaxrsServer.java
+++ b/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/SofaNettyJaxrsServer.java
@@ -63,7 +63,7 @@ import static org.jboss.resteasy.plugins.server.netty.RestEasyHttpRequestDecoder
  */
 public class SofaNettyJaxrsServer implements EmbeddedJaxrsServer {
 
-    private final ServerConfig               serverConfig;
+    private final ServerConfig         serverConfig;
     protected ServerBootstrap          bootstrap           = new ServerBootstrap();
     protected String                   hostname            = null;
     protected int                      port                = 8080;
@@ -218,7 +218,8 @@ public class SofaNettyJaxrsServer implements EmbeddedJaxrsServer {
             eventExecutor = new EpollEventLoopGroup(executorThreadCount, new NamedThreadFactory("SEV-REST-BIZ-" + port,
                 serverConfig.isDaemon()));
         } else {
-            eventLoopGroup = new NioEventLoopGroup(ioWorkerCount, new NamedThreadFactory("SEV-REST-IO-" + port, serverConfig.isDaemon()));
+            eventLoopGroup = new NioEventLoopGroup(ioWorkerCount, new NamedThreadFactory("SEV-REST-IO-" + port,
+                serverConfig.isDaemon()));
             eventExecutor = new NioEventLoopGroup(executorThreadCount, new NamedThreadFactory("SEV-REST-BIZ-" + port,
                 serverConfig.isDaemon()));
         }


### PR DESCRIPTION
### question

As of [sofa v5.4.0](https://github.com/alipay/sofa-rpc/tree/v5.4.0), `SofaNettyJaxrsServer` `RestServer` `AbstractHttp2ClientTransport` aren't fully support `epoll` IO model correctly.

### Your advice

Add fully `epoll` IO model support by the option `epoll` comes from `ClientTransportConfig` and `ServerConfig`

### Environment

- SOFARPC version: v5.4.0
- OS version: Linux Family