### PR TITLE
Remove dead connection from manager before reconnect.

### DIFF
--- a/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/transport/bolt/BoltClientTransport.java
+++ b/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/transport/bolt/BoltClientTransport.java
@@ -144,7 +144,7 @@ public class BoltClientTransport extends ClientTransport {
     public void connect() {
         if (connection != null) {
             if (!connection.isFine()) {
-                connectionManager.closeConnection(RPC_CLIENT, transportConfig, url);
+                connection.close();
                 connection = null;
             }
         }

--- a/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/transport/bolt/BoltClientTransport.java
+++ b/extension-impl/remoting-bolt/src/main/java/com/alipay/sofa/rpc/transport/bolt/BoltClientTransport.java
@@ -144,7 +144,7 @@ public class BoltClientTransport extends ClientTransport {
     public void connect() {
         if (connection != null) {
             if (!connection.isFine()) {
-                connection.close();
+                connectionManager.closeConnection(RPC_CLIENT, transportConfig, url);
                 connection = null;
             }
         }

--- a/extension-impl/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/HttpServerHandler.java
+++ b/extension-impl/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/HttpServerHandler.java
@@ -61,10 +61,6 @@ public class HttpServerHandler implements ServerHandler {
         return processingCount;
     }
 
-    public HttpServerHandler(ThreadPoolExecutor bizThreadPool) {
-        this.bizThreadPool = bizThreadPool;
-    }
-
     @Override
     public void registerChannel(AbstractChannel nettyChannel) {
 
@@ -138,5 +134,10 @@ public class HttpServerHandler implements ServerHandler {
 
     public ThreadPoolExecutor getBizThreadPool() {
         return bizThreadPool;
+    }
+
+    public HttpServerHandler setBizThreadPool(ThreadPoolExecutor bizThreadPool) {
+        this.bizThreadPool = bizThreadPool;
+        return this;
     }
 }

--- a/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/RestServer.java
+++ b/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/RestServer.java
@@ -69,6 +69,7 @@ public class RestServer implements Server {
     @Override
     public void init(ServerConfig serverConfig) {
         this.serverConfig = serverConfig;
+        httpServer = buildServer();
     }
 
     private SofaNettyJaxrsServer buildServer() {
@@ -136,7 +137,6 @@ public class RestServer implements Server {
             }
             // 绑定到端口
             try {
-                httpServer = buildServer();
                 httpServer.start();
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("Start the http rest server at port {}", serverConfig.getPort());
@@ -170,7 +170,6 @@ public class RestServer implements Server {
                 LOGGER.info("Stop the http rest server at port {}", serverConfig.getPort());
             }
             httpServer.stop();
-            httpServer = null;
         } catch (Exception e) {
             LOGGER.error("Stop the http rest server at port " + serverConfig.getPort() + " error !", e);
         }
@@ -222,6 +221,7 @@ public class RestServer implements Server {
     @Override
     public void destroy() {
         stop();
+        httpServer = null;
     }
 
     @Override

--- a/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/SofaNettyJaxrsServer.java
+++ b/extension-impl/remoting-resteasy/src/main/java/com/alipay/sofa/rpc/server/rest/SofaNettyJaxrsServer.java
@@ -20,7 +20,6 @@ import com.alipay.sofa.rpc.common.SystemInfo;
 import com.alipay.sofa.rpc.common.struct.NamedThreadFactory;
 import com.alipay.sofa.rpc.common.utils.StringUtils;
 import com.alipay.sofa.rpc.config.ServerConfig;
-
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
@@ -64,7 +63,7 @@ import static org.jboss.resteasy.plugins.server.netty.RestEasyHttpRequestDecoder
 public class SofaNettyJaxrsServer implements EmbeddedJaxrsServer {
 
     private final ServerConfig         serverConfig;
-    protected ServerBootstrap          bootstrap           = new ServerBootstrap();
+    protected ServerBootstrap          bootstrap           = null;
     protected String                   hostname            = null;
     protected int                      port                = 8080;
     protected ResteasyDeployment       deployment          = new SofaResteasyDeployment(); // CHANGE: 使用sofa的类
@@ -224,7 +223,7 @@ public class SofaNettyJaxrsServer implements EmbeddedJaxrsServer {
                 serverConfig.isDaemon()));
         }
         // Configure the server.
-        bootstrap
+        bootstrap = new ServerBootstrap()
             .group(eventLoopGroup)
             .channel(
                 (serverConfig != null && serverConfig.isEpoll()) ? EpollServerSocketChannel.class
@@ -293,5 +292,6 @@ public class SofaNettyJaxrsServer implements EmbeddedJaxrsServer {
             eventExecutor.shutdownGracefully().sync();
         } catch (Exception ignore) { // NOPMD
         }
+        bootstrap = null;
     }
 }

--- a/test/test-common/src/main/java/com/alipay/sofa/rpc/test/TestUtils.java
+++ b/test/test-common/src/main/java/com/alipay/sofa/rpc/test/TestUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.test;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
+ */
+public class TestUtils {
+
+    public static <T> T delayGet(Callable<T> callable, T expect, int period, int times) {
+        T result = null;
+        int i = 0;
+        while (i++ < times) {
+            try {
+                Thread.sleep(period);
+                result = callable.call();
+                if (result != null && result.equals(expect)) {
+                    break;
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return result;
+    }
+}

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/client/bolt/BoltDirectUrlTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/client/bolt/BoltDirectUrlTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.client.bolt;
+
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+import com.alipay.sofa.rpc.config.ApplicationConfig;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.test.ActivelyDestroyTest;
+import com.alipay.sofa.rpc.test.HelloService;
+import com.alipay.sofa.rpc.test.HelloServiceImpl;
+import com.alipay.sofa.rpc.test.TestUtils;
+import org.junit.Assert;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
+ */
+public class BoltDirectUrlTest extends ActivelyDestroyTest {
+
+    // @Test
+    // FIXME 目前bolt的IO线程关闭时未释放，暂不支持本测试用例
+    public void testAll() {
+        // 只有2个线程 执行
+        ServerConfig serverConfig = new ServerConfig()
+            .setPort(12300)
+            .setProtocol(RpcConstants.PROTOCOL_TYPE_BOLT)
+            .setDaemon(true);
+
+        // 发布一个服务，每个请求要执行1秒
+        ProviderConfig<HelloService> providerConfig = new ProviderConfig<HelloService>()
+            .setInterfaceId(HelloService.class.getName())
+            .setRef(new HelloServiceImpl())
+            .setBootstrap("bolt")
+            .setApplication(new ApplicationConfig().setAppName("serverApp"))
+            .setServer(serverConfig)
+            .setRegister(false);
+        providerConfig.export();
+
+        final ConsumerConfig<HelloService> consumerConfig = new ConsumerConfig<HelloService>()
+            .setInterfaceId(HelloService.class.getName())
+            .setDirectUrl("bolt://127.0.0.1:12300")
+            .setProtocol(RpcConstants.PROTOCOL_TYPE_BOLT)
+            .setBootstrap("bolt")
+            .setApplication(new ApplicationConfig().setAppName("clientApp"))
+            .setReconnectPeriod(1000);
+
+        HelloService helloService = consumerConfig.refer();
+
+        Assert.assertNotNull(helloService.sayHello("xx", 22));
+
+        serverConfig.getServer().stop();
+
+        // 关闭后再调用一个抛异常
+        try {
+            helloService.sayHello("xx", 22);
+        } catch (Exception e) {
+            // 应该抛出异常
+            Assert.assertTrue(e instanceof SofaRpcException);
+        }
+
+        Assert.assertTrue(TestUtils.delayGet(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return CommonUtils.isEmpty(consumerConfig.getConsumerBootstrap()
+                    .getCluster().getConnectionHolder().getAvailableConnections());
+            }
+        }, true, 50, 40));
+
+        serverConfig.getServer().start();
+        // 等待客户端重连服务端
+        Assert.assertTrue(TestUtils.delayGet(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return CommonUtils.isNotEmpty(consumerConfig.getConsumerBootstrap()
+                    .getCluster().getConnectionHolder().getAvailableConnections());
+            }
+        }, true, 50, 60));
+
+        Assert.assertNotNull(helloService.sayHello("xx", 22));
+    }
+}

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/client/h2c/H2cDirectUrlTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/client/h2c/H2cDirectUrlTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.client.h2c;
+
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+import com.alipay.sofa.rpc.config.ApplicationConfig;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.server.http.ExampleObj;
+import com.alipay.sofa.rpc.server.http.HttpService;
+import com.alipay.sofa.rpc.server.http.HttpServiceImpl;
+import com.alipay.sofa.rpc.test.ActivelyDestroyTest;
+import com.alipay.sofa.rpc.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
+ */
+public class H2cDirectUrlTest extends ActivelyDestroyTest {
+
+    @Test
+    public void testAll() throws InterruptedException {
+
+        // 只有1个线程 执行
+        ServerConfig serverConfig = new ServerConfig()
+            .setPort(12300)
+            .setProtocol(RpcConstants.PROTOCOL_TYPE_H2C)
+            .setDaemon(true);
+
+        // 发布一个服务，每个请求要执行1秒
+        ProviderConfig<HttpService> providerConfig = new ProviderConfig<HttpService>()
+            .setInterfaceId(HttpService.class.getName())
+            .setRef(new HttpServiceImpl())
+            .setBootstrap("h2c")
+            .setApplication(new ApplicationConfig().setAppName("serverApp"))
+            .setServer(serverConfig)
+            .setRegister(false);
+        providerConfig.export();
+
+        final ConsumerConfig<HttpService> consumerConfig = new ConsumerConfig<HttpService>()
+            .setInterfaceId(HttpService.class.getName())
+            .setDirectUrl("h2c://127.0.0.1:12300")
+            .setProtocol(RpcConstants.PROTOCOL_TYPE_H2C)
+            .setBootstrap("h2c")
+            .setApplication(new ApplicationConfig().setAppName("clientApp"))
+            .setReconnectPeriod(1000);
+
+        HttpService httpService = consumerConfig.refer();
+
+        ExampleObj request = new ExampleObj();
+        request.setId(200);
+        request.setName("yyy");
+        ExampleObj response = httpService.object(request);
+        Assert.assertEquals(200, response.getId());
+        Assert.assertEquals("yyyxx", response.getName());
+
+        serverConfig.getServer().stop();
+
+        // 关闭后再调用一个抛异常
+        try {
+            httpService.object(request);
+        } catch (Exception e) {
+            // 应该抛出异常
+            Assert.assertTrue(e instanceof SofaRpcException);
+        }
+
+        Assert.assertTrue(TestUtils.delayGet(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return CommonUtils.isEmpty(consumerConfig.getConsumerBootstrap()
+                    .getCluster().getConnectionHolder().getAvailableConnections());
+            }
+        }, true, 50, 40));
+
+        serverConfig.getServer().start();
+        // 等待客户端重连服务端
+        Assert.assertTrue(TestUtils.delayGet(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return CommonUtils.isNotEmpty(consumerConfig.getConsumerBootstrap()
+                    .getCluster().getConnectionHolder().getAvailableConnections());
+            }
+        }, true, 50, 60));
+
+        response = httpService.object(request);
+        Assert.assertEquals(200, response.getId());
+        Assert.assertEquals("yyyxx", response.getName());
+    }
+}

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/client/rest/RestDirectUrlTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/client/rest/RestDirectUrlTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.client.rest;
+
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.common.utils.CommonUtils;
+import com.alipay.sofa.rpc.config.ApplicationConfig;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.core.exception.SofaRpcException;
+import com.alipay.sofa.rpc.server.rest.RestService;
+import com.alipay.sofa.rpc.server.rest.RestServiceImpl;
+import com.alipay.sofa.rpc.test.ActivelyDestroyTest;
+import com.alipay.sofa.rpc.test.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
+ */
+public class RestDirectUrlTest extends ActivelyDestroyTest {
+
+    @Test
+    public void testAll() {
+
+        // 只有1个线程 执行
+        ServerConfig serverConfig = new ServerConfig()
+            .setPort(12300)
+            .setProtocol(RpcConstants.PROTOCOL_TYPE_REST)
+            .setDaemon(true);
+
+        // 发布一个服务，每个请求要执行1秒
+        ProviderConfig<RestService> providerConfig = new ProviderConfig<RestService>()
+            .setInterfaceId(RestService.class.getName())
+            .setRef(new RestServiceImpl())
+            .setBootstrap("rest")
+            .setApplication(new ApplicationConfig().setAppName("serverApp"))
+            .setServer(serverConfig)
+            .setRegister(false);
+        providerConfig.export();
+
+        final ConsumerConfig<RestService> consumerConfig = new ConsumerConfig<RestService>()
+            .setInterfaceId(RestService.class.getName())
+            .setDirectUrl("rest://127.0.0.1:12300")
+            .setProtocol(RpcConstants.PROTOCOL_TYPE_REST)
+            .setBootstrap("rest")
+            .setApplication(new ApplicationConfig().setAppName("clientApp"))
+            .setReconnectPeriod(1000);
+
+        RestService restService = consumerConfig.refer();
+
+        Assert.assertEquals(restService.query(11), "hello world !null");
+
+        serverConfig.getServer().stop();
+
+        // 关闭后再调用一个抛异常
+        try {
+            restService.query(11);
+        } catch (Exception e) {
+            // 应该抛出异常
+            Assert.assertTrue(e instanceof SofaRpcException);
+        }
+
+        Assert.assertTrue(TestUtils.delayGet(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return CommonUtils.isEmpty(consumerConfig.getConsumerBootstrap()
+                    .getCluster().getConnectionHolder().getAvailableConnections());
+            }
+        }, true, 50, 40));
+
+        serverConfig.getServer().start();
+        // 等待客户端重连服务端
+        Assert.assertTrue(TestUtils.delayGet(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return CommonUtils.isNotEmpty(consumerConfig.getConsumerBootstrap()
+                    .getCluster().getConnectionHolder().getAvailableConnections());
+            }
+        }, true, 50, 60));
+
+        Assert.assertEquals(restService.query(11), "hello world !null");
+    }
+}


### PR DESCRIPTION
### Modification:

- Remove dead connection from manager before reconnect.
- Fix reconnect behaviour of h2c and rest.

PS: Because of bolt-1.4.2 don't release IOEventGroup when `stop()`, so I can't write unit test case.

### Result:

Fixes #178 