### PR TITLE
Remove Unused Annotation

### DIFF
--- a/extension-impl/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/AbstractHttpServer.java
+++ b/extension-impl/remoting-http/src/main/java/com/alipay/sofa/rpc/server/http/AbstractHttpServer.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ThreadPoolExecutor;
  * @author <a href="mailto:zhanggeng.zg@antfin.com">GengZhang</a>
  * @since 5.4.0
  */
-@Extension("http")
 public abstract class AbstractHttpServer implements Server {
 
     protected final String container;


### PR DESCRIPTION
### Motivation:
There are some unsed annotions in abstract class because it is unnecessary and its implements have their own annotation,for example @Extension("http") in com.alipay.sofa.rpc.server.http.AbstractHttpServer

### Modification:
Remove unsed annotions in abstract class.I have already checked 22 abstract class,only com.alipay.sofa.rpc.server.http.AbstractHttpServer has @Extension annotion, so just remove this class annotion.

### Result:

Fixes #192. 