### PR TITLE
Fix consumer exception missing when void method from provider is called with exception.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ jdk:
 before_install:
   - echo "Downloading Maven 3.2.5" 
    && wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip 
-   && unzip -qq apache-maven-3.2.5-bin.zip 
+   && unzip -q apache-maven-3.2.5-bin.zip 
    && export M2_HOME=$PWD/apache-maven-3.2.5 
    && export PATH=$M2_HOME/bin:$PATH 
+   && cp ./tools/ci/.travis.settings.xml $HOME/.m2/settings.xml
    && mvn -version
   - echo "Install Zookeeper 3.4.11"
    && wget http://archive.apache.org/dist/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz

--- a/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
+++ b/core-impl/proxy/src/main/java/com/alipay/sofa/rpc/proxy/javassist/JavassistProxy.java
@@ -168,16 +168,16 @@ public class JavassistProxy implements Proxy {
                 " response.getErrorMsg());");
             sb.append("}");
 
+            sb.append("Object ret = response.getAppResponse();");
+            sb.append("if (ret instanceof " + Throwable.class.getName() + ") {");
+            sb.append("    throw (" + Throwable.class.getName() + ") ret;");
+            sb.append("} else {");
             if (returnType.equals(void.class)) {
                 sb.append(" return;");
             } else {
-                sb.append("Object ret = response.getAppResponse();");
-                sb.append("if(ret instanceof " + Throwable.class.getName() + ") {");
-                sb.append("    throw (" + Throwable.class.getName() + ") ret;");
-                sb.append("} else {");
-                sb.append("    return " + asArgument(returnType, "ret") + ";");
-                sb.append("}");
+                sb.append(" return " + asArgument(returnType, "ret") + ";");
             }
+            sb.append("}");
 
             sb.append("}");
             resultList.add(sb.toString());

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/exception/BizThrowExceptionTest.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/exception/BizThrowExceptionTest.java
@@ -52,36 +52,52 @@ public class BizThrowExceptionTest extends ActivelyDestroyTest {
             .setRegister(false);
         providerConfig.export();
 
-        ConsumerConfig<TestExceptionService> consumerConfig = new ConsumerConfig<TestExceptionService>()
-            .setInterfaceId(TestExceptionService.class.getName())
-            .setDirectUrl("bolt://127.0.0.1:22222")
-            .setTimeout(1000)
-            .setRegister(false);
-        final TestExceptionService service = consumerConfig.refer();
+        for (String proxy : new String[] { "jdk", "javassist" }) {
+            ConsumerConfig<TestExceptionService> consumerConfig = new ConsumerConfig<TestExceptionService>()
+                .setInterfaceId(TestExceptionService.class.getName())
+                .setDirectUrl("bolt://127.0.0.1:22222")
+                .setTimeout(1000)
+                .setProxy(proxy)
+                .setRepeatedReferLimit(-1)
+                .setRegister(false);
+            final TestExceptionService service = consumerConfig.refer();
 
-        try {
-            service.throwRuntimeException();
-        } catch (Throwable e) {
-            Assert.assertTrue(e instanceof RuntimeException);
-            Assert.assertEquals(e.getMessage(), "RuntimeException");
-        }
-        try {
-            service.throwException();
-        } catch (Throwable e) {
-            Assert.assertTrue(e instanceof Exception);
-            Assert.assertEquals(e.getMessage(), "Exception");
-        }
-        try {
-            service.throwSofaException();
-        } catch (Throwable e) {
-            Assert.assertTrue(e instanceof SofaRpcException);
-            Assert.assertEquals(e.getMessage(), "SofaRpcException");
-        }
-        try {
-            service.throwDeclaredException();
-        } catch (Throwable e) {
-            Assert.assertTrue(e instanceof TestException);
-            Assert.assertEquals(e.getMessage(), "TestException");
+            try {
+                service.throwRuntimeException();
+                Assert.fail();
+            } catch (Throwable e) {
+                Assert.assertTrue(e instanceof RuntimeException);
+                Assert.assertEquals(e.getMessage(), "RuntimeException");
+            }
+            try {
+                service.throwException();
+                Assert.fail();
+            } catch (Throwable e) {
+                Assert.assertTrue(e instanceof Exception);
+                Assert.assertEquals(e.getMessage(), "Exception");
+            }
+            try {
+                service.throwSofaException();
+                Assert.fail();
+            } catch (Throwable e) {
+                Assert.assertTrue(e instanceof SofaRpcException);
+                Assert.assertEquals(e.getMessage(), "SofaRpcException");
+            }
+            try {
+                service.throwDeclaredException();
+                Assert.fail();
+            } catch (Throwable e) {
+                Assert.assertTrue(e instanceof TestException);
+                Assert.assertEquals(e.getMessage(), "TestException");
+            }
+
+            try {
+                service.throwDeclaredExceptionWithoutReturn();
+                Assert.fail();
+            } catch (Throwable e) {
+                Assert.assertTrue(e instanceof TestException);
+                Assert.assertEquals(e.getMessage(), "DeclaredExceptionWithoutReturn");
+            }
         }
     }
 }

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/exception/TestExceptionService.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/exception/TestExceptionService.java
@@ -32,4 +32,6 @@ public interface TestExceptionService {
     public String throwSofaException() throws SofaRpcException;
 
     public String throwDeclaredException() throws TestException;
+
+    public void throwDeclaredExceptionWithoutReturn() throws TestException;
 }

--- a/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/exception/TestExceptionServiceImpl.java
+++ b/test/test-integration/src/test/java/com/alipay/sofa/rpc/test/exception/TestExceptionServiceImpl.java
@@ -43,4 +43,9 @@ public class TestExceptionServiceImpl implements TestExceptionService {
     public String throwDeclaredException() throws TestException {
         throw new TestException("TestException");
     }
+
+    @Override
+    public void throwDeclaredExceptionWithoutReturn() throws TestException {
+        throw new TestException("DeclaredExceptionWithoutReturn");
+    }
 }

--- a/tools/ci/.travis.settings.xml
+++ b/tools/ci/.travis.settings.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!-- https://github.com/travis-ci/travis-cookbooks/blob/master/cookbooks/travis_build_environment/files/default/ci_user/maven_user_settings.xml -->
+    <profiles>
+        <profile>
+            <id>standard-with-extra-repos</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <name>Central Repository</name>
+                    <url>http://repo1.maven.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </repository>
+
+                <repository>
+                    <id>central2</id>
+                    <name>Central Repository 2</name>
+                    <url>http://repo1.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </repository>
+
+                <repository>
+                    <id>sonatype</id>
+                    <name>OSS Sonatype repo (releases)</name>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>fail</checksumPolicy>
+                    </snapshots>
+                    <url>https://oss.sonatype.org/content/repositories/releases/</url>
+                </repository>
+
+                <repository>
+                    <id>sonatype-snapshots</id>
+                    <name>OSS Sonatype repo (snapshots)</name>
+                    <releases>
+                        <enabled>false</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>fail</checksumPolicy>
+                    </snapshots>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+                </repository>
+
+                <repository>
+                    <id>sonatype-apache</id>
+                    <name>Apache repo (releases)</name>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>fail</checksumPolicy>
+                    </snapshots>
+                    <url>https://repository.apache.org/releases/</url>
+                </repository>
+
+                <repository>
+                    <id>apache-snapshots</id>
+                    <name>ASF repo (snapshots)</name>
+                    <releases>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>fail</checksumPolicy>
+                    </snapshots>
+                    <url>https://repository.apache.org/snapshots/</url>
+                </repository>
+
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>central</id>
+                    <!-- specify repo1 which support http -->
+                    <url>http://repo1.maven.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </pluginRepository>
+
+                <pluginRepository>
+                    <id>central2</id>
+                    <!-- specify repo1 which support http -->
+                    <url>http://repo1.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+</settings>


### PR DESCRIPTION
If you use `javassist` proxy (default is `jdk`) and the method return type is `void`. when the method throws exception in server side, the client side will ignore, it's a bug. 