### PR TITLE
统一管理插件，解决插件版本不一致导致编译出错

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,9 +114,6 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.7.9</version>
                 </plugin>
-            </plugins>
-        </pluginManagement>
-        <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -252,6 +249,7 @@
                 </executions>
             </plugin>
         </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>


### PR DESCRIPTION
Signed-off-by: humyna <hufo125@gmail.com>

### Motivation:
代码导入eclipse后由于maven版本问题，子项目编译报错

### Modification:
修改parent中pom.xml中pluginManagement

### Result:
统一管理maven插件
