### PR TITLE
Fix ZookeeperRegistry destroy by DestroyHook invoke error.

### DIFF
--- a/extension-impl/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java
+++ b/extension-impl/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java
@@ -240,7 +240,7 @@ public class ZookeeperRegistry extends Registry {
 
     @Override
     public void destroy(DestroyHook hook) {
-        hook.postDestroy();
+        hook.preDestroy();
         destroy();
         hook.postDestroy();
     }


### PR DESCRIPTION
### Motivation:

从DestroyHook的设计看，应当是调用真实的destroy方法前，先调用DestroyHook的preDestroy方法，再执行destroy。而不是前置调用DestroyHook的postDestroy方法。

### Modification:

将前置调用的postDestroy方法替换为preDestroy。

### Result:

