### PR TITLE
Fix incorrect version of dependencies.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
         <jetty.version>7.5.4.v20111024</jetty.version>
         <curator.version>2.9.1</curator.version>
         <opentracing.version>0.22.0</opentracing.version>
-        <dubbo_version>2.4.10</dubbo_version>
+        <dubbo.version>2.4.10</dubbo.version>
         <!-- serialization -->
         <hessian.version>3.3.2</hessian.version>
         <thrift.version>0.9.2</thrift.version>
@@ -29,6 +29,7 @@
         <msgpack.version>0.6.11</msgpack.version>
         <!--common-->
         <httpcomponents.version>4.4.9</httpcomponents.version>
+        <httpcomponents.httpmime.version>4.5.5</httpcomponents.httpmime.version>
         <commons.fileupload.version>1.3.3</commons.fileupload.version>
         <!-- Log libs -->
         <slf4j.version>1.7.21</slf4j.version>
@@ -111,7 +112,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
-                <version>${httpcomponents.version}</version>
+                <version>${httpcomponents.httpmime.version}</version>
             </dependency>
 
             <dependency>
@@ -274,7 +275,7 @@
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>dubbo</artifactId>
-                <version>${dubbo_version}</version>
+                <version>${dubbo.version}</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>javassist</artifactId>


### PR DESCRIPTION
### Motivation:
fix httpmime version not exsit error and change dubbo_version to dubbo.version

### Modification:

1、change httpmime version from 4.4.9 to 4.5.5
2、change dubbo_version to dubbo.version

### Result:

Fixes https://github.com/alipay/sofa-rpc/issues/292
