### PR TITLE
Add auth support for zookeeper registry

### DIFF
--- a/extension-impl/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java
+++ b/extension-impl/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java
@@ -218,18 +218,18 @@ public class ZookeeperRegistry extends Registry {
         }
         RetryPolicy retryPolicy = new ExponentialBackoffRetry(1000, 3);
         CuratorFrameworkFactory.Builder zkClientuilder = CuratorFrameworkFactory.builder()
-                .connectString(address)
-                .sessionTimeoutMs(registryConfig.getConnectTimeout() * 3)
-                .connectionTimeoutMs(registryConfig.getConnectTimeout())
-                .canBeReadOnly(false)
-                .retryPolicy(retryPolicy)
-                .defaultData(null);
+            .connectString(address)
+            .sessionTimeoutMs(registryConfig.getConnectTimeout() * 3)
+            .connectionTimeoutMs(registryConfig.getConnectTimeout())
+            .canBeReadOnly(false)
+            .retryPolicy(retryPolicy)
+            .defaultData(null);
 
         //是否需要添加zk的认证信息
         List<AuthInfo> authInfos = buildAuthInfo();
         if (CommonUtils.isNotEmpty(authInfos)) {
             zkClientuilder = zkClientuilder.aclProvider(getDefaultAclProvider())
-                    .authorization(authInfos);
+                .authorization(authInfos);
         }
 
         zkClient = zkClientuilder.build();

--- a/extension-impl/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java
+++ b/extension-impl/registry-zk/src/main/java/com/alipay/sofa/rpc/registry/zk/ZookeeperRegistry.java
@@ -37,8 +37,10 @@ import com.alipay.sofa.rpc.log.Logger;
 import com.alipay.sofa.rpc.log.LoggerFactory;
 import com.alipay.sofa.rpc.registry.Registry;
 import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.AuthInfo;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.ACLProvider;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
@@ -48,8 +50,11 @@ import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
 
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -212,14 +217,22 @@ public class ZookeeperRegistry extends Registry {
                 address, rootPath, preferLocalFile, ephemeralNode);
         }
         RetryPolicy retryPolicy = new ExponentialBackoffRetry(1000, 3);
-        zkClient = CuratorFrameworkFactory.builder()
-            .connectString(address)
-            .sessionTimeoutMs(registryConfig.getConnectTimeout() * 3)
-            .connectionTimeoutMs(registryConfig.getConnectTimeout())
-            .canBeReadOnly(false)
-            .retryPolicy(retryPolicy)
-            .defaultData(null)
-            .build();
+        CuratorFrameworkFactory.Builder zkClientuilder = CuratorFrameworkFactory.builder()
+                .connectString(address)
+                .sessionTimeoutMs(registryConfig.getConnectTimeout() * 3)
+                .connectionTimeoutMs(registryConfig.getConnectTimeout())
+                .canBeReadOnly(false)
+                .retryPolicy(retryPolicy)
+                .defaultData(null);
+
+        //是否需要添加zk的认证信息
+        List<AuthInfo> authInfos = buildAuthInfo();
+        if (CommonUtils.isNotEmpty(authInfos)) {
+            zkClientuilder = zkClientuilder.aclProvider(getDefaultAclProvider())
+                    .authorization(authInfos);
+        }
+
+        zkClient = zkClientuilder.build();
 
         zkClient.getConnectionStateListenable().addListener(new ConnectionStateListener() {
             @Override
@@ -746,5 +759,45 @@ public class ZookeeperRegistry extends Registry {
                 LOGGER.error("Close PathChildrenCache error!", e);
             }
         }
+    }
+
+    /**
+     * 获取默认的AclProvider
+     * @return
+     */
+    private ACLProvider getDefaultAclProvider() {
+        return new ACLProvider() {
+            @Override
+            public List<ACL> getDefaultAcl() {
+                return ZooDefs.Ids.CREATOR_ALL_ACL;
+            }
+
+            @Override
+            public List<ACL> getAclForPath(String path) {
+                return ZooDefs.Ids.CREATOR_ALL_ACL;
+            }
+        };
+    }
+
+    /**
+     * 创建认证信息
+     * @return
+     */
+    private List<AuthInfo> buildAuthInfo() {
+        List<AuthInfo> info = new ArrayList<AuthInfo>();
+
+        String scheme = registryConfig.getParameter("scheme");
+
+        //如果存在多个认证信息，则在参数形式为为addAuth=user1:paasswd1,user2:passwd2
+        String addAuth = registryConfig.getParameter("addAuth");
+
+        if (StringUtils.isNotEmpty(addAuth)) {
+            String[] addAuths = addAuth.split(",");
+            for (String singleAuthInfo : addAuths) {
+                info.add(new AuthInfo(scheme, singleAuthInfo.getBytes()));
+            }
+        }
+
+        return info;
     }
 }

--- a/test/test-integration-3rd/src/test/java/com/alipay/sofa/rpc/registry/zk/auth/ZookeeperAuthBoltServerTest.java
+++ b/test/test-integration-3rd/src/test/java/com/alipay/sofa/rpc/registry/zk/auth/ZookeeperAuthBoltServerTest.java
@@ -36,8 +36,8 @@ import java.util.Map;
  */
 public class ZookeeperAuthBoltServerTest extends BaseZkTest {
 
-    private static ServerConfig   serverConfig;
-    private static RegistryConfig registryConfig;
+    private static ServerConfig        serverConfig;
+    private static RegistryConfig      registryConfig;
 
     private static Map<String, String> parameters = new HashMap<String, String>();
 
@@ -48,16 +48,15 @@ public class ZookeeperAuthBoltServerTest extends BaseZkTest {
         parameters.put("addAuth", "sofazk:rpc1");
 
         registryConfig = new RegistryConfig()
-                .setProtocol("zookeeper")
-                .setAddress("127.0.0.1:2181/authtest")
-                .setParameters(parameters);
+            .setProtocol("zookeeper")
+            .setAddress("127.0.0.1:2181/authtest")
+            .setParameters(parameters);
 
         serverConfig = new ServerConfig()
-                .setProtocol("bolt") // 设置一个协议，默认bolt
-                .setPort(12200) // 设置一个端口，默认12200
-                .setDaemon(false); // 非守护线程
+            .setProtocol("bolt") // 设置一个协议，默认bolt
+            .setPort(12200) // 设置一个端口，默认12200
+            .setDaemon(false); // 非守护线程
     }
-
 
     @AfterClass
     public static void destroy() {
@@ -68,10 +67,10 @@ public class ZookeeperAuthBoltServerTest extends BaseZkTest {
     public void testAll() {
 
         ProviderConfig<EchoService> providerConfig = new ProviderConfig<EchoService>()
-                .setRegistry(registryConfig)
-                .setInterfaceId(EchoService.class.getName()) // 指定接口
-                .setRef(new EchoServiceImpl()) // 指定实现
-                .setServer(serverConfig); // 指定服务端
+            .setRegistry(registryConfig)
+            .setInterfaceId(EchoService.class.getName()) // 指定接口
+            .setRef(new EchoServiceImpl()) // 指定实现
+            .setServer(serverConfig); // 指定服务端
         providerConfig.export(); // 发布服务
 
         ConsumerConfig<EchoService> consumerConfig = new ConsumerConfig<EchoService>()
@@ -87,6 +86,5 @@ public class ZookeeperAuthBoltServerTest extends BaseZkTest {
         Assert.assertEquals("auth test", result);
 
     }
-
 
 }

--- a/test/test-integration-3rd/src/test/java/com/alipay/sofa/rpc/registry/zk/auth/ZookeeperAuthBoltServerTest.java
+++ b/test/test-integration-3rd/src/test/java/com/alipay/sofa/rpc/registry/zk/auth/ZookeeperAuthBoltServerTest.java
@@ -20,9 +20,12 @@ import com.alipay.sofa.rpc.config.ConsumerConfig;
 import com.alipay.sofa.rpc.config.ProviderConfig;
 import com.alipay.sofa.rpc.config.RegistryConfig;
 import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.registry.base.BaseZkTest;
 import com.alipay.sofa.rpc.test.EchoService;
 import com.alipay.sofa.rpc.test.EchoServiceImpl;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -31,31 +34,44 @@ import java.util.Map;
 /**
  * @author <a href="mailto:jjzxjgy@126.com">jianyang</a>
  */
-public class ZookeeperAuthBoltServerTest {
+public class ZookeeperAuthBoltServerTest extends BaseZkTest {
+
+    private static ServerConfig   serverConfig;
+    private static RegistryConfig registryConfig;
+
+    private static Map<String, String> parameters = new HashMap<String, String>();
+
+    @BeforeClass
+    public static void setUp() {
+        parameters.put("scheme", "digest");
+        //如果存在多个认证信息，则在参数形式为为user1:passwd1,user2:passwd2
+        parameters.put("addAuth", "sofazk:rpc1");
+
+        registryConfig = new RegistryConfig()
+                .setProtocol("zookeeper")
+                .setAddress("127.0.0.1:2181/authtest")
+                .setParameters(parameters);
+
+        serverConfig = new ServerConfig()
+                .setProtocol("bolt") // 设置一个协议，默认bolt
+                .setPort(12200) // 设置一个端口，默认12200
+                .setDaemon(false); // 非守护线程
+    }
+
+
+    @AfterClass
+    public static void destroy() {
+        serverConfig.destroy();
+    }
 
     @Test
     public void testAll() {
 
-        Map<String, String> parameters = new HashMap<String, String>();
-        parameters.put("scheme", "digest");
-        //如果存在多个认证信息，则在参数形式为为user1:paasswd1,user2:passwd2
-        parameters.put("addAuth", "sofazk:rpc");
-
-        RegistryConfig registryConfig = new RegistryConfig()
-            .setProtocol("zookeeper")
-            .setAddress("127.0.0.1:2181/authtest")
-            .setParameters(parameters);
-
-        ServerConfig serverConfig = new ServerConfig()
-            .setProtocol("bolt") // 设置一个协议，默认bolt
-            .setPort(12200) // 设置一个端口，默认12200
-            .setDaemon(false); // 非守护线程
-
         ProviderConfig<EchoService> providerConfig = new ProviderConfig<EchoService>()
-            .setRegistry(registryConfig)
-            .setInterfaceId(EchoService.class.getName()) // 指定接口
-            .setRef(new EchoServiceImpl()) // 指定实现
-            .setServer(serverConfig); // 指定服务端
+                .setRegistry(registryConfig)
+                .setInterfaceId(EchoService.class.getName()) // 指定接口
+                .setRef(new EchoServiceImpl()) // 指定实现
+                .setServer(serverConfig); // 指定服务端
         providerConfig.export(); // 发布服务
 
         ConsumerConfig<EchoService> consumerConfig = new ConsumerConfig<EchoService>()
@@ -71,4 +87,6 @@ public class ZookeeperAuthBoltServerTest {
         Assert.assertEquals("auth test", result);
 
     }
+
+
 }

--- a/test/test-integration-3rd/src/test/java/com/alipay/sofa/rpc/registry/zk/auth/ZookeeperAuthBoltServerTest.java
+++ b/test/test-integration-3rd/src/test/java/com/alipay/sofa/rpc/registry/zk/auth/ZookeeperAuthBoltServerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.rpc.registry.zk.auth;
 
 import com.alipay.sofa.rpc.config.ConsumerConfig;
@@ -26,35 +42,33 @@ public class ZookeeperAuthBoltServerTest {
         parameters.put("addAuth", "sofazk:rpc");
 
         RegistryConfig registryConfig = new RegistryConfig()
-                .setProtocol("zookeeper")
-                .setAddress("127.0.0.1:2181/authtest")
-                .setParameters(parameters);
-
+            .setProtocol("zookeeper")
+            .setAddress("127.0.0.1:2181/authtest")
+            .setParameters(parameters);
 
         ServerConfig serverConfig = new ServerConfig()
-                .setProtocol("bolt") // 设置一个协议，默认bolt
-                .setPort(12200) // 设置一个端口，默认12200
-                .setDaemon(false); // 非守护线程
+            .setProtocol("bolt") // 设置一个协议，默认bolt
+            .setPort(12200) // 设置一个端口，默认12200
+            .setDaemon(false); // 非守护线程
 
         ProviderConfig<EchoService> providerConfig = new ProviderConfig<EchoService>()
-                .setRegistry(registryConfig)
-                .setInterfaceId(EchoService.class.getName()) // 指定接口
-                .setRef(new EchoServiceImpl()) // 指定实现
-                .setServer(serverConfig); // 指定服务端
+            .setRegistry(registryConfig)
+            .setInterfaceId(EchoService.class.getName()) // 指定接口
+            .setRef(new EchoServiceImpl()) // 指定实现
+            .setServer(serverConfig); // 指定服务端
         providerConfig.export(); // 发布服务
 
         ConsumerConfig<EchoService> consumerConfig = new ConsumerConfig<EchoService>()
-                .setRegistry(registryConfig)
-                .setInterfaceId(EchoService.class.getName()) // 指定接口
-                .setProtocol("bolt") // 指定协议
-                .setTimeout(3000)
-                .setConnectTimeout(10 * 1000);
+            .setRegistry(registryConfig)
+            .setInterfaceId(EchoService.class.getName()) // 指定接口
+            .setProtocol("bolt") // 指定协议
+            .setTimeout(3000)
+            .setConnectTimeout(10 * 1000);
         EchoService echoService = consumerConfig.refer();
 
         String result = echoService.echoStr("auth test");
 
         Assert.assertEquals("auth test", result);
-
 
     }
 }

--- a/test/test-integration-3rd/src/test/java/com/alipay/sofa/rpc/registry/zk/auth/ZookeeperAuthBoltServerTest.java
+++ b/test/test-integration-3rd/src/test/java/com/alipay/sofa/rpc/registry/zk/auth/ZookeeperAuthBoltServerTest.java
@@ -1,0 +1,60 @@
+package com.alipay.sofa.rpc.registry.zk.auth;
+
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.config.ProviderConfig;
+import com.alipay.sofa.rpc.config.RegistryConfig;
+import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.test.EchoService;
+import com.alipay.sofa.rpc.test.EchoServiceImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:jjzxjgy@126.com">jianyang</a>
+ */
+public class ZookeeperAuthBoltServerTest {
+
+    @Test
+    public void testAll() {
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("scheme", "digest");
+        //如果存在多个认证信息，则在参数形式为为user1:paasswd1,user2:passwd2
+        parameters.put("addAuth", "sofazk:rpc");
+
+        RegistryConfig registryConfig = new RegistryConfig()
+                .setProtocol("zookeeper")
+                .setAddress("127.0.0.1:2181/authtest")
+                .setParameters(parameters);
+
+
+        ServerConfig serverConfig = new ServerConfig()
+                .setProtocol("bolt") // 设置一个协议，默认bolt
+                .setPort(12200) // 设置一个端口，默认12200
+                .setDaemon(false); // 非守护线程
+
+        ProviderConfig<EchoService> providerConfig = new ProviderConfig<EchoService>()
+                .setRegistry(registryConfig)
+                .setInterfaceId(EchoService.class.getName()) // 指定接口
+                .setRef(new EchoServiceImpl()) // 指定实现
+                .setServer(serverConfig); // 指定服务端
+        providerConfig.export(); // 发布服务
+
+        ConsumerConfig<EchoService> consumerConfig = new ConsumerConfig<EchoService>()
+                .setRegistry(registryConfig)
+                .setInterfaceId(EchoService.class.getName()) // 指定接口
+                .setProtocol("bolt") // 指定协议
+                .setTimeout(3000)
+                .setConnectTimeout(10 * 1000);
+        EchoService echoService = consumerConfig.refer();
+
+        String result = echoService.echoStr("auth test");
+
+        Assert.assertEquals("auth test", result);
+
+
+    }
+}


### PR DESCRIPTION
### Motivation:
在使用zk作为注册中心的过程中，由于当前版本没有认证功能，在生产环境的安全扫描流程时，被当做漏洞扫描出来了，所以添加了一个digest方式的认证。

### Modification:

在配置zk的连接地址时，如果需要添加认证，就在地址后面加上&scheme=digest&addAuth=user1:paasswd1
如果存在多个认证信息，认证参数形式为为addAuth=user1:paasswd1,user2:passwd2

### Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
