### PR TITLE
support other serialization type for bolt

### DIFF
--- a/extension-impl/bootstrap-bolt/pom.xml
+++ b/extension-impl/bootstrap-bolt/pom.xml
@@ -22,6 +22,22 @@
             <artifactId>sofa-rpc-extension-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+         <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-rpc-remoting-bolt</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>        
     </dependencies>
 
     <build>

--- a/extension-impl/bootstrap-bolt/pom.xml
+++ b/extension-impl/bootstrap-bolt/pom.xml
@@ -22,12 +22,6 @@
             <artifactId>sofa-rpc-extension-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-         <dependency>
-            <groupId>com.alipay.sofa</groupId>
-            <artifactId>sofa-rpc-remoting-bolt</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -37,7 +31,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
     </dependencies>
 
     <build>

--- a/extension-impl/bootstrap-bolt/src/main/java/com/alipay/sofa/rpc/bootstrap/bolt/BoltClientProxyInvoker.java
+++ b/extension-impl/bootstrap-bolt/src/main/java/com/alipay/sofa/rpc/bootstrap/bolt/BoltClientProxyInvoker.java
@@ -58,7 +58,7 @@ public class BoltClientProxyInvoker extends DefaultClientProxyInvoker {
         } else if (SERIALIZE_JAVA.equals(serialization)) {
             serializeType = RemotingConstants.SERIALIZE_CODE_JAVA;
         } else {
-            throw new SofaRpcRuntimeException("Unsupported serialization type");
+            serializeType = super.parseSerializeType(serialization);
         }
         return serializeType;
     }

--- a/extension-impl/bootstrap-bolt/src/test/java/com/alipay/sofa/rpc/bootstrap/bolt/BoltClientProxyInvokerTest.java
+++ b/extension-impl/bootstrap-bolt/src/test/java/com/alipay/sofa/rpc/bootstrap/bolt/BoltClientProxyInvokerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.rpc.bootstrap.bolt;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import com.alipay.sofa.rpc.bootstrap.Bootstraps;
+import com.alipay.sofa.rpc.bootstrap.ConsumerBootstrap;
+import com.alipay.sofa.rpc.common.RemotingConstants;
+import com.alipay.sofa.rpc.common.RpcConstants;
+import com.alipay.sofa.rpc.config.ConsumerConfig;
+import com.alipay.sofa.rpc.core.exception.SofaRpcRuntimeException;
+
+/**
+ *
+ *
+ * @author <a href="mailto:njucoder@gmail.com">Min Li</a>
+ */
+public class BoltClientProxyInvokerTest {
+    @Test
+    public void testParseSerializeType() throws Exception {
+        ConsumerConfig consumerConfig = new ConsumerConfig().setProtocol("bolt");
+        ConsumerBootstrap bootstrap = Bootstraps.from(consumerConfig);
+        BoltClientProxyInvoker invoker = new BoltClientProxyInvoker(bootstrap);
+        byte actual = invoker.parseSerializeType(RpcConstants.SERIALIZE_HESSIAN2);
+        assertEquals(RemotingConstants.SERIALIZE_CODE_HESSIAN, actual);
+    }
+
+    @Test(expected = SofaRpcRuntimeException.class)
+    public void testParseSerializeTypeException() {
+        ConsumerConfig consumerConfig = new ConsumerConfig().setProtocol("bolt");
+        ConsumerBootstrap bootstrap = Bootstraps.from(consumerConfig);
+        BoltClientProxyInvoker invoker = new BoltClientProxyInvoker(bootstrap);
+        invoker.parseSerializeType("unknown");
+    }
+}

--- a/extension-impl/bootstrap-bolt/src/test/resources/log4j.xml
+++ b/extension-impl/bootstrap-bolt/src/test/resources/log4j.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d %t %5p [%c:%M:%L] - %m%n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <level value="INFO"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</log4j:configuration>

--- a/extension-impl/bootstrap-bolt/src/test/resources/sofa-rpc/rpc-config.json
+++ b/extension-impl/bootstrap-bolt/src/test/resources/sofa-rpc/rpc-config.json
@@ -1,0 +1,4 @@
+{
+  "rpc.config.order": 999,  // 加载顺序，越大越后加载
+  "logger.impl": "com.alipay.sofa.rpc.log.SLF4JLoggerImpl"
+}


### PR DESCRIPTION
### Motivation:

support serialization framework for bolt implementation.

### Modification:

BoltClientProxyInvoker.parseSerializeType call super.parseSerializeType

### Result:

Fixes #504

