### PR TITLE
Support nacos tests on windows

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -22,7 +22,7 @@
         <curator.version>2.9.1</curator.version>
         <opentracing.version>0.22.0</opentracing.version>
         <dubbo.version>2.4.10</dubbo.version>
-        <nacos.version>0.6.0</nacos.version>
+        <nacos.version>0.9.0</nacos.version>
         <!-- serialization -->
         <hessian.version>3.3.6</hessian.version>
         <thrift.version>0.9.2</thrift.version>

--- a/extension-impl/registry-nacos/pom.xml
+++ b/extension-impl/registry-nacos/pom.xml
@@ -37,49 +37,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>name.jervyshi</groupId>
+            <artifactId>nacos-embedded</artifactId>
+            <version>0.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
-                <executions>
-                    <execution>
-                        <id>start-nacos-server</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <workingDirectory>${project.basedir}</workingDirectory>
-                            <executable>bash</executable>
-                            <arguments>
-                                <argument>${project.basedir}${file.separator}src${file.separator}test${file.separator}scripts${file.separator}start-nacos-server.sh</argument>
-                            </arguments>
-                            <skip>${skipTests}</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>stop-nacos-server</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <workingDirectory>${project.basedir}</workingDirectory>
-                            <executable>bash</executable>
-                            <arguments>
-                                <argument>${project.basedir}${file.separator}src${file.separator}test${file.separator}scripts${file.separator}stop-nacos-server.sh</argument>
-                            </arguments>
-                            <skip>${skipTests}</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <profiles>
         <profile>

--- a/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryTest.java
+++ b/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/NacosRegistryTest.java
@@ -26,9 +26,9 @@ import com.alipay.sofa.rpc.config.ServerConfig;
 import com.alipay.sofa.rpc.listener.ProviderInfoListener;
 import com.alipay.sofa.rpc.registry.RegistryFactory;
 import com.alipay.sofa.rpc.registry.nacos.base.BaseNacosTest;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -47,17 +47,17 @@ public class NacosRegistryTest extends BaseNacosTest {
 
     private static RegistryConfig registryConfig;
 
-    private static NacosRegistry  registry;
+    private NacosRegistry         registry;
 
     /**
      * Sets up.
      */
-    @BeforeClass
-    public static void setUp() {
+    @Before
+    public void setUp() {
         registryConfig = new RegistryConfig()
             .setProtocol("nacos")
             .setSubscribe(true)
-            .setAddress("127.0.0.1:8848")
+            .setAddress("127.0.0.1:" + nacosProcess.getServerPort())
             .setRegister(true);
 
         registry = (NacosRegistry) RegistryFactory.getRegistry(registryConfig);
@@ -68,8 +68,8 @@ public class NacosRegistryTest extends BaseNacosTest {
     /**
      * Tear down.
      */
-    @AfterClass
-    public static void tearDown() {
+    @After
+    public void tearDown() {
         registry.destroy();
         registry = null;
     }

--- a/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/base/BaseNacosTest.java
+++ b/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/base/BaseNacosTest.java
@@ -20,7 +20,11 @@ import com.alipay.sofa.rpc.context.RpcInternalContext;
 import com.alipay.sofa.rpc.context.RpcInvokeContext;
 import com.alipay.sofa.rpc.context.RpcRunningState;
 import com.alipay.sofa.rpc.context.RpcRuntimeContext;
+import name.jervyshi.nacos.NacosProcess;
+import name.jervyshi.nacos.NacosStarterBuilder;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 /**
@@ -28,6 +32,8 @@ import org.junit.BeforeClass;
  * @author <a href=mailto:jervyshi@gmail.com>JervyShi</a>
  */
 public abstract class BaseNacosTest {
+
+    protected NacosProcess nacosProcess;
 
     /**
      * Ad before class.
@@ -45,5 +51,15 @@ public abstract class BaseNacosTest {
         RpcRuntimeContext.destroy();
         RpcInternalContext.removeContext();
         RpcInvokeContext.removeContext();
+    }
+
+    @Before
+    public void setup() {
+        nacosProcess = NacosStarterBuilder.nacosStarter().withNacosVersion("0.9.0").build().start();
+    }
+    
+    @After
+    public void cleanup() throws Exception {
+        nacosProcess.close();
     }
 }

--- a/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/base/BaseNacosTest.java
+++ b/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/base/BaseNacosTest.java
@@ -57,7 +57,7 @@ public abstract class BaseNacosTest {
     public void setup() {
         nacosProcess = NacosStarterBuilder.nacosStarter().withNacosVersion("0.9.0").build().start();
     }
-    
+
     @After
     public void cleanup() throws Exception {
         nacosProcess.close();


### PR DESCRIPTION
### Motivation:

Support nacos tests on windows.

### Modification:

Change nacos Integration tests using [nacos-embedded](https://github.com/JervyShi/nacos-embedded).

Upgrade nacos client version to `0.9.0`

### Result:

Fixes #569 . 

If there is no issue then describe the changes introduced by this PR.
