### PR TITLE
Exclude sofa-common-tools dependency of sofa-bolt.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -245,6 +245,10 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.alipay.sofa.common</groupId>
+                    <artifactId>sofa-common-tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
排除bolt包下sofa-common-tools依赖

### Motivation:

all 包依赖了sofa-common-tools包，而引用的二方包bolt也存在sofa-common-tools，且版本不一致，all包为新版本，sofa-common-tools为低版本

### Modification:

通过排除bolt包下sofa-common-tools依赖解决

### Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
