### PR TITLE
Upgrade nacos client version to 1.0.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -22,7 +22,7 @@
         <curator.version>2.9.1</curator.version>
         <opentracing.version>0.22.0</opentracing.version>
         <dubbo.version>2.4.10</dubbo.version>
-        <nacos.version>0.9.0</nacos.version>
+        <nacos.version>1.0.0</nacos.version>
         <sofa.registry.version>5.2.0</sofa.registry.version>
         <!-- serialization -->
         <hessian.version>3.3.6</hessian.version>

--- a/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/base/BaseNacosTest.java
+++ b/extension-impl/registry-nacos/src/test/java/com/alipay/sofa/rpc/registry/nacos/base/BaseNacosTest.java
@@ -55,7 +55,7 @@ public abstract class BaseNacosTest {
 
     @Before
     public void setup() {
-        nacosProcess = NacosStarterBuilder.nacosStarter().withNacosVersion("0.9.0").build().start();
+        nacosProcess = NacosStarterBuilder.nacosStarter().withNacosVersion("1.0.0").build().start();
     }
 
     @After


### PR DESCRIPTION
### Modification:

Upgrade nacos client version to `1.0.0`.

### Result:

Fixes #577

If there is no issue then describe the changes introduced by this PR.
